### PR TITLE
Fix errors when interacting with newer Hadoop clusters

### DIFF
--- a/webhdfs/webhdfs.py
+++ b/webhdfs/webhdfs.py
@@ -92,10 +92,13 @@ class WebHDFS(object):
         self._get_url(path), params=p, verify=self._verify, stream=True)
     self._process_response(r)
     try:
-      f = sys.stdout if ldst == '-' else open(ldst, 'w')
+      f = sys.stdout if ldst == '-' else open(ldst, 'wb')
+      d = (ldst == '-')
       for chunk in r.iter_content(chunk_size=2**16):
         if chunk: # filter out keep-alive new chunks
-          f.write(chunk)
+          f.write(
+            chunk.decode('utf-8') if d else chunk
+          )
     finally:
       if f is not sys.stdout:
         f.close()
@@ -155,7 +158,7 @@ class WebHDFS(object):
       'permission': permission,
       'overwrite': overwrite
     }
-    with open(lsrc, 'r') as f:
+    with open(lsrc, 'rb') as f:
       r = self._s.put(
           self._get_url(path), params=p, data=f, verify=self._verify)
       self._process_response(r)

--- a/webhdfs/webhdfs.py
+++ b/webhdfs/webhdfs.py
@@ -119,8 +119,11 @@ class WebHDFS(object):
     p = {
       'op':'append'
     }
+    h = {
+      'content-type':'application/octet-stream'
+    }
     r = self._s.post(
-        self._get_url(path), params=p, data=data, verify=self._verify)
+        self._get_url(path), params=p, headers=h, data=data, verify=self._verify)
     self._process_response(r)
 
   def set_owner(self, path, owner='', group=''):
@@ -158,9 +161,12 @@ class WebHDFS(object):
       'permission': permission,
       'overwrite': overwrite
     }
+    h = {
+      'content-type':'application/octet-stream'
+    }
     with open(lsrc, 'rb') as f:
       r = self._s.put(
-          self._get_url(path), params=p, data=f, verify=self._verify)
+          self._get_url(path), params=p, headers=h, data=f, verify=self._verify)
       self._process_response(r)
 
   def create_symlink(self, path, dest, createParent=False):


### PR DESCRIPTION
When working with binary data or when interacting with a newer version of Hadoop this CLI currently fails. I committed the fixes for the two issues I found as separate commits with commit messages for more detailed info.